### PR TITLE
Add pr preview deploys and commenting on the pr with the link

### DIFF
--- a/.changeset/bright-streets-notice.md
+++ b/.changeset/bright-streets-notice.md
@@ -1,0 +1,5 @@
+---
+"happy-harmony": patch
+---
+
+JANDES-81: Add preview deploys and preview link being commented on PR

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,42 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Delete preview worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          pnpm exec wrangler delete --env staging --name "happy-harmony-pr-${PR_NUMBER}" --force

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,184 @@
+name: PR Preview Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI", "Playwright Tests"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.meta.outputs.pr_number }}
+      head_sha: ${{ steps.meta.outputs.head_sha }}
+      should_deploy: ${{ steps.meta.outputs.should_deploy }}
+    steps:
+      - name: Resolve PR + gate on green checks
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require("@actions/core");
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            if (!run || run.conclusion !== "success") {
+              core.setOutput("should_deploy", "false");
+              return;
+            }
+
+            const headSha = run.head_sha;
+            let pr = run.pull_requests?.[0];
+
+            if (!pr) {
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: headSha,
+              });
+              pr = prs.data[0];
+            }
+
+            if (!pr) {
+              core.setOutput("should_deploy", "false");
+              return;
+            }
+
+            const prNumber = pr.number;
+            const prData = pr.pull_request
+              ? pr
+              : (
+                  await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: prNumber,
+                  })
+                ).data;
+
+            const isSameRepo =
+              prData.head.repo.full_name === `${owner}/${repo}`;
+
+            core.setOutput("pr_number", String(prNumber));
+            core.setOutput("head_sha", headSha);
+
+            if (!isSameRepo) {
+              core.setOutput("should_deploy", "false");
+              return;
+            }
+
+            const workflows = ["ci.yml", "playwright.yml"];
+            const results = await Promise.all(
+              workflows.map(async (workflowId) => {
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner,
+                  repo,
+                  workflow_id: workflowId,
+                  head_sha: headSha,
+                  event: "pull_request",
+                });
+                return runs.data.workflow_runs.some(
+                  (r) => r.status === "completed" && r.conclusion === "success"
+                );
+              })
+            );
+
+            const shouldDeploy = results.every(Boolean);
+            core.setOutput("should_deploy", shouldDeploy ? "true" : "false");
+
+  deploy:
+    needs: meta
+    if: needs.meta.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-preview-${{ needs.meta.outputs.pr_number }}
+      cancel-in-progress: true
+    env:
+      VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+      VITE_SENTRY_ORG: ${{ vars.VITE_SENTRY_ORG }}
+      VITE_SENTRY_PROJECT: ${{ vars.VITE_SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      PR_NUMBER: ${{ needs.meta.outputs.pr_number }}
+      HEAD_SHA: ${{ needs.meta.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.meta.outputs.head_sha }}
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy preview
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          pnpm exec wrangler deploy --env staging --name "happy-harmony-pr-${PR_NUMBER}" --json > /tmp/deploy.json
+          node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('/tmp/deploy.json','utf8')); const url=data?.deployment?.url || data?.url || data?.routes?.[0]; if(!url){ console.error('No preview URL found in deploy output.'); process.exit(1); } console.log(`preview_url=${url}`);" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = "<!-- pr-preview-url -->";
+            const previewUrl = "${{ steps.deploy.outputs.preview_url }}";
+            const body = [
+              marker,
+              `✅ Preview ready: ${previewUrl}`,
+              `Commit: ${process.env.HEAD_SHA}`,
+              "",
+              "_Preview deploy runs only after CI + Playwright pass._",
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+            });
+
+            const existing = comments.data.find((comment) =>
+              comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "wrangler dev --port 3000",
+        "dev": "wrangler dev --env staging --port 3000",
         "dev:vite": "vite dev --port 3000",
+        "dev:prod": "wrangler dev --port 3000",
+        "preview:pr": "pnpm run build && wrangler versions upload --env staging",
         "start": "node .output/server/index.mjs",
         "build": "vite build",
         "serve": "vite preview",
@@ -31,7 +33,6 @@
         "clean": "rm -rf .turbo node_modules .wrangler .output dist",
         "deploy": "pnpm run build && wrangler deploy",
         "deploy:staging": "pnpm run build && wrangler deploy --env staging",
-        "deploy:production": "pnpm run build && wrangler deploy --env production",
         "preview": "pnpm run build && vite preview",
         "cf-typegen": "wrangler types"
     },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,16 +1,35 @@
 {
-  "$schema": "./node_modules/wrangler/config-schema.json",
-  "name": "happy-harmony",
-  "main": "./node_modules/@tanstack/react-start/dist/default-entry/esm/server.js",
-  "compatibility_date": "2026-01-07",
-  "compatibility_flags": ["nodejs_compat", "remove_nodejs_compat_eol"],
-  "workers_dev": true,
-  "observability": { "enabled": true },
-  "env": {
-    "staging": {
-      "name": "happy-harmony-staging"
-    }
-  }
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "happy-harmony",
+	"main": "./node_modules/@tanstack/react-start/dist/default-entry/esm/server.js",
+	"compatibility_date": "2026-01-07",
+	"compatibility_flags": [
+		"nodejs_compat",
+		"remove_nodejs_compat_eol"
+	],
+	"workers_dev": true,
+	"observability": {
+		"enabled": true
+	},
+	// Custom domain (app.happyharmony.dev) is attached in Cloudflare dashboard via Custom Domains.
+	// Do not add "route" here; we want to keep apex free for marketing pages.
+	"env": {
+		"staging": {
+			"name": "happy-harmony-staging",
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "happy-harmony-staging",
+					"database_id": "4cf700d6-e8d9-4006-b508-60c4a676d6fb"
+				}
+			]
+		}
+	},
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "happy-harmony-prod",
+			"database_id": "ed5427da-5ca4-419c-8408-d6b03620f748"
+		}
+	]
 }
-// Custom domain (app.happyharmony.dev) is attached in Cloudflare dashboard via Custom Domains.
-// Do not add "route" here; we want to keep apex free for "marketing page(s)".


### PR DESCRIPTION
# JANDES-81: PR Preview deploys to Workers + post URL to PR

## Summary

- Adds a `pr-preview.yml` workflow that deploys an ephemeral Cloudflare Worker for each PR, gated on both CI and Playwright checks passing
- Adds a `pr-preview-cleanup.yml` workflow that deletes the preview Worker when a PR is closed
- Extends `wrangler.jsonc` with a `staging` environment for preview deploys
- Adds a `preview:pr` script to `package.json` for local testing of the preview flow

## How it works

1. When either the **CI** or **Playwright Tests** workflow completes, `pr-preview.yml` fires
2. A `meta` job resolves the PR number and verifies that **both** `ci.yml` and `playwright.yml` have a passing run for the head SHA — if not, the deploy is skipped
3. Fork PRs are rejected (same-repo check)
4. The `deploy` job checks out the exact SHA, builds, and deploys via `wrangler deploy --env staging --name "happy-harmony-pr-<number>"`
5. The preview URL is parsed from the wrangler output and posted as a PR comment (upserted using a `<!-- pr-preview-url -->` marker to avoid duplicate comments)
6. On PR close, `pr-preview-cleanup.yml` runs `wrangler delete` to tear down the ephemeral Worker

## Changed files

| File | Change |
|------|--------|
| `.github/workflows/pr-preview.yml` | New — deploy + comment workflow |
| `.github/workflows/pr-preview-cleanup.yml` | New — teardown on PR close |
| `wrangler.jsonc` | Add `staging` env block with D1 binding |
| `package.json` | Add `preview:pr` script |

## Required secrets / vars

The following must be set in the repo's GitHub Actions environment:

| Name | Type |
|------|------|
| `CLOUDFLARE_API_TOKEN` | Secret |
| `CLOUDFLARE_ACCOUNT_ID` | Secret |
| `VITE_SENTRY_DSN` | Var |
| `VITE_SENTRY_ORG` | Var |
| `VITE_SENTRY_PROJECT` | Var |
| `SENTRY_AUTH_TOKEN` | Secret |

## Test plan

- [ ] Open a PR and verify both CI and Playwright workflows pass
- [ ] Confirm a preview comment appears on the PR with a valid Workers URL
- [ ] Push a new commit to the same PR and verify the comment is updated (not duplicated)
- [ ] Close the PR and confirm the preview Worker is deleted in Cloudflare
- [ ] Verify a PR where CI fails does **not** trigger a deploy