### PR TITLE
Booshja/jandes 86/schema v1

### DIFF
--- a/.changeset/twelve-rivers-search.md
+++ b/.changeset/twelve-rivers-search.md
@@ -1,0 +1,5 @@
+---
+"happy-harmony": patch
+---
+
+Add V1 database schema: category, activity, and suggestion_history tables with Drizzle migration and

--- a/drizzle/0000_violet_mephistopheles.sql
+++ b/drizzle/0000_violet_mephistopheles.sql
@@ -1,0 +1,89 @@
+CREATE TABLE `account` (
+	`id` text PRIMARY KEY NOT NULL,
+	`accountId` text NOT NULL,
+	`providerId` text NOT NULL,
+	`userId` text NOT NULL,
+	`accessToken` text,
+	`refreshToken` text,
+	`idToken` text,
+	`accessTokenExpiresAt` integer,
+	`refreshTokenExpiresAt` integer,
+	`scope` text,
+	`password` text,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `activity` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`displayId` text NOT NULL,
+	`userId` text NOT NULL,
+	`categoryId` integer,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`duration` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`categoryId`) REFERENCES `category`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `activity_displayId_unique` ON `activity` (`displayId`);--> statement-breakpoint
+CREATE TABLE `category` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`displayId` text NOT NULL,
+	`userId` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `category_displayId_unique` ON `category` (`displayId`);--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`expiresAt` integer NOT NULL,
+	`token` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	`ipAddress` text,
+	`userAgent` text,
+	`userId` text NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_token_unique` ON `session` (`token`);--> statement-breakpoint
+CREATE TABLE `suggestionHistory` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`displayId` text NOT NULL,
+	`userId` text NOT NULL,
+	`activityId` integer,
+	`userInput` text NOT NULL,
+	`suggestionOutput` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`activityId`) REFERENCES `activity`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `suggestionHistory_displayId_unique` ON `suggestionHistory` (`displayId`);--> statement-breakpoint
+CREATE TABLE `user` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`emailVerified` integer DEFAULT false NOT NULL,
+	`image` text,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
+CREATE TABLE `verification` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expiresAt` integer NOT NULL,
+	`createdAt` integer,
+	`updatedAt` integer
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,586 @@
+{
+    "version": "6",
+    "dialect": "sqlite",
+    "id": "4a8a0f1d-358e-461d-8074-040b8d6e44fb",
+    "prevId": "00000000-0000-0000-0000-000000000000",
+    "tables": {
+        "account": {
+            "name": "account",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "accountId": {
+                    "name": "accountId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "providerId": {
+                    "name": "providerId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "accessToken": {
+                    "name": "accessToken",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "refreshToken": {
+                    "name": "refreshToken",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "idToken": {
+                    "name": "idToken",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "accessTokenExpiresAt": {
+                    "name": "accessTokenExpiresAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "refreshTokenExpiresAt": {
+                    "name": "refreshTokenExpiresAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "scope": {
+                    "name": "scope",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "account_userId_user_id_fk": {
+                    "name": "account_userId_user_id_fk",
+                    "tableFrom": "account",
+                    "tableTo": "user",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "activity": {
+            "name": "activity",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "integer",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": true
+                },
+                "displayId": {
+                    "name": "displayId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "categoryId": {
+                    "name": "categoryId",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "duration": {
+                    "name": "duration",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {
+                "activity_displayId_unique": {
+                    "name": "activity_displayId_unique",
+                    "columns": ["displayId"],
+                    "isUnique": true
+                }
+            },
+            "foreignKeys": {
+                "activity_userId_user_id_fk": {
+                    "name": "activity_userId_user_id_fk",
+                    "tableFrom": "activity",
+                    "tableTo": "user",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "activity_categoryId_category_id_fk": {
+                    "name": "activity_categoryId_category_id_fk",
+                    "tableFrom": "activity",
+                    "tableTo": "category",
+                    "columnsFrom": ["categoryId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "category": {
+            "name": "category",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "integer",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": true
+                },
+                "displayId": {
+                    "name": "displayId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {
+                "category_displayId_unique": {
+                    "name": "category_displayId_unique",
+                    "columns": ["displayId"],
+                    "isUnique": true
+                }
+            },
+            "foreignKeys": {
+                "category_userId_user_id_fk": {
+                    "name": "category_userId_user_id_fk",
+                    "tableFrom": "category",
+                    "tableTo": "user",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "session": {
+            "name": "session",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "expiresAt": {
+                    "name": "expiresAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "ipAddress": {
+                    "name": "ipAddress",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "userAgent": {
+                    "name": "userAgent",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {
+                "session_token_unique": {
+                    "name": "session_token_unique",
+                    "columns": ["token"],
+                    "isUnique": true
+                }
+            },
+            "foreignKeys": {
+                "session_userId_user_id_fk": {
+                    "name": "session_userId_user_id_fk",
+                    "tableFrom": "session",
+                    "tableTo": "user",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "suggestionHistory": {
+            "name": "suggestionHistory",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "integer",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": true
+                },
+                "displayId": {
+                    "name": "displayId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "activityId": {
+                    "name": "activityId",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "userInput": {
+                    "name": "userInput",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "suggestionOutput": {
+                    "name": "suggestionOutput",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {
+                "suggestionHistory_displayId_unique": {
+                    "name": "suggestionHistory_displayId_unique",
+                    "columns": ["displayId"],
+                    "isUnique": true
+                }
+            },
+            "foreignKeys": {
+                "suggestionHistory_userId_user_id_fk": {
+                    "name": "suggestionHistory_userId_user_id_fk",
+                    "tableFrom": "suggestionHistory",
+                    "tableTo": "user",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "suggestionHistory_activityId_activity_id_fk": {
+                    "name": "suggestionHistory_activityId_activity_id_fk",
+                    "tableFrom": "suggestionHistory",
+                    "tableTo": "activity",
+                    "columnsFrom": ["activityId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "user": {
+            "name": "user",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "emailVerified": {
+                    "name": "emailVerified",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": false
+                },
+                "image": {
+                    "name": "image",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {
+                "user_email_unique": {
+                    "name": "user_email_unique",
+                    "columns": ["email"],
+                    "isUnique": true
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "verification": {
+            "name": "verification",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "identifier": {
+                    "name": "identifier",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "value": {
+                    "name": "value",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "expiresAt": {
+                    "name": "expiresAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        }
+    },
+    "views": {},
+    "enums": {},
+    "_meta": {
+        "schemas": {},
+        "tables": {},
+        "columns": {}
+    },
+    "internal": {
+        "indexes": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,1 +1,13 @@
-{ "version": "7", "dialect": "sqlite", "entries": [] }
+{
+    "version": "7",
+    "dialect": "sqlite",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "6",
+            "when": 1774142319753,
+            "tag": "0000_violet_mephistopheles",
+            "breakpoints": true
+        }
+    ]
+}

--- a/drizzle/seeds/seed.sql
+++ b/drizzle/seeds/seed.sql
@@ -1,1 +1,24 @@
--- Seed data will be added here in JANDES-86.
+-- Demo user (no password — auth-managed; used for local dev/demo only)
+INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES
+    ('demo-user-1', 'Demo User', 'demo@example.com', 1,
+     strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000);
+
+-- Categories
+INSERT INTO category (displayId, userId, name, description, createdAt, updatedAt) VALUES
+    ('cat-1', 'demo-user-1', 'Work',     'Work-related tasks and projects', strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000),
+    ('cat-2', 'demo-user-1', 'Personal', 'Personal errands and goals',      strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000),
+    ('cat-3', 'demo-user-1', 'Health',   'Health and wellness activities',   strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000);
+
+-- Activities
+INSERT INTO activity (displayId, userId, categoryId, name, description, duration, createdAt, updatedAt) VALUES
+    ('act-1', 'demo-user-1', 1, 'Ship v1 feature',    'Focus on core flow only',  '3 hours',  strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000),
+    ('act-2', 'demo-user-1', 1, 'Review PR feedback',  'Address review comments',  '30 min',   strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000),
+    ('act-3', 'demo-user-1', 2, 'Call family',         'Weekly catch-up call',     '30 min',   strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000),
+    ('act-4', 'demo-user-1', 3, 'Morning walk',        '30 minutes around park',   '30 min',   strftime('%s', 'now') * 1000, strftime('%s', 'now') * 1000);
+
+-- Suggestion history
+INSERT INTO suggestionHistory (displayId, userId, activityId, userInput, suggestionOutput, createdAt) VALUES
+    ('sug-1', 'demo-user-1', 1,
+     'Work task, need to focus',
+     'Break the task into small steps and tackle one at a time.',
+     strftime('%s', 'now') * 1000);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,2 +1,113 @@
-// Schema tables will be defined here in JANDES-86.
-export {};
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+// -- better-auth tables --
+
+export const user = sqliteTable("user", {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: integer("emailVerified", { mode: "boolean" })
+        .notNull()
+        .default(false),
+    image: text("image"),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updatedAt", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const session = sqliteTable("session", {
+    id: text("id").primaryKey(),
+    expiresAt: integer("expiresAt", { mode: "timestamp_ms" }).notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updatedAt", { mode: "timestamp_ms" }).notNull(),
+    ipAddress: text("ipAddress"),
+    userAgent: text("userAgent"),
+    userId: text("userId")
+        .notNull()
+        .references(() => user.id, { onDelete: "cascade" }),
+});
+
+export const account = sqliteTable("account", {
+    id: text("id").primaryKey(),
+    accountId: text("accountId").notNull(),
+    providerId: text("providerId").notNull(),
+    userId: text("userId")
+        .notNull()
+        .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("accessToken"),
+    refreshToken: text("refreshToken"),
+    idToken: text("idToken"),
+    accessTokenExpiresAt: integer("accessTokenExpiresAt", {
+        mode: "timestamp_ms",
+    }),
+    refreshTokenExpiresAt: integer("refreshTokenExpiresAt", {
+        mode: "timestamp_ms",
+    }),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updatedAt", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const verification = sqliteTable("verification", {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: integer("expiresAt", { mode: "timestamp_ms" }).notNull(),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }),
+    updatedAt: integer("updatedAt", { mode: "timestamp_ms" }),
+});
+
+// -- app tables --
+
+export const category = sqliteTable("category", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    displayId: text("displayId").notNull().unique(),
+    userId: text("userId")
+        .notNull()
+        .references(() => user.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updatedAt", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const activity = sqliteTable("activity", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    displayId: text("displayId").notNull().unique(),
+    userId: text("userId")
+        .notNull()
+        .references(() => user.id, { onDelete: "cascade" }),
+    categoryId: integer("categoryId").references(() => category.id, {
+        onDelete: "set null",
+    }),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    duration: text("duration", {
+        enum: [
+            "5 min",
+            "10-15 min",
+            "30 min",
+            "1 hour",
+            "3 hours",
+            "Half day",
+            "Full day",
+        ],
+    }).notNull(),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updatedAt", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const suggestionHistory = sqliteTable("suggestionHistory", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    displayId: text("displayId").notNull().unique(),
+    userId: text("userId")
+        .notNull()
+        .references(() => user.id, { onDelete: "cascade" }),
+    activityId: integer("activityId").references(() => activity.id, {
+        onDelete: "set null",
+    }),
+    userInput: text("userInput").notNull(),
+    suggestionOutput: text("suggestionOutput").notNull(),
+    createdAt: integer("createdAt", { mode: "timestamp_ms" }).notNull(),
+});

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9425,7 +9425,7 @@ type AIGatewayHeaders = {
     [key: string]: string | number | boolean | object;
 };
 type AIGatewayUniversalRequest = {
-    provider: AIGatewayProviders | string;  
+    provider: AIGatewayProviders | string;
     endpoint: string;
     headers: Partial<AIGatewayHeaders>;
     query: unknown;
@@ -9442,7 +9442,7 @@ declare abstract class AiGateway {
             extraHeaders?: object;
         },
     ): Promise<Response>;
-    getUrl(provider?: AIGatewayProviders | string): Promise<string>;  
+    getUrl(provider?: AIGatewayProviders | string): Promise<string>;
 }
 interface AutoRAGInternalError extends Error {}
 interface AutoRAGNotFoundError extends Error {}


### PR DESCRIPTION
# JANDES-86: Schema v1 migrations (users/categories/activities/history)

## Summary

- Defines the V1 Drizzle schema across 7 tables: 4 managed by better-auth (`user`, `session`, `account`, `verification`) and 3 app tables (`category`, `activity`, `suggestionHistory`)
- Generates the initial D1 migration (`0000_violet_mephistopheles.sql`) covering all tables
- Adds demo seed data for local development (1 user, 3 categories, 4 activities, 1 suggestion history entry)
- Regenerates `worker-configuration.d.ts` with `DB: D1Database` binding type so typecheck passes without running `cf-typegen` locally

## Schema design decisions

- **better-auth tables** use `text` UUID primary keys — required for better-auth adapter compatibility
- **App tables** (`category`, `activity`, `suggestionHistory`) use `integer` autoincrement PKs for efficient joins, plus a `text displayId` (UUID) for safe external exposure in URLs/APIs
- Timestamps stored as `integer({ mode: "timestamp_ms" })` (Unix milliseconds) — standard for SQLite/D1 with Drizzle
- All foreign keys pointing to `user.id` use `onDelete: "cascade"` per the privacy spec hard-delete requirement
- `activity.categoryId` and `suggestionHistory.activityId` use `onDelete: "set null"` so deleting a category/activity doesn't cascade-delete dependent records

## Changed files

| File | Change |
|------|--------|
| `src/db/schema.ts` | Define all 7 tables |
| `drizzle/0000_violet_mephistopheles.sql` | Generated migration (new) |
| `drizzle/meta/_journal.json` | Updated migration journal |
| `drizzle/meta/0000_snapshot.json` | Generated schema snapshot (new) |
| `drizzle/seeds/seed.sql` | Demo seed data for local dev |
| `worker-configuration.d.ts` | Regenerated with `DB: D1Database` |

## Test plan

- [ ] `pnpm db:generate` — reruns cleanly with no schema drift
- [ ] `pnpm db:reset && pnpm db:seed` — local D1 migrates and seeds without error
- [ ] `pnpm typecheck` — passes with `DB: D1Database` in scope
- [ ] `pnpm test` — all tests pass
- [ ] `wrangler d1 execute DB --local --command "SELECT * FROM user;"` — returns demo user row
