### PR TITLE
Booshja/jandes 122/automated staging deploy

### DIFF
--- a/.changeset/social-rings-sip.md
+++ b/.changeset/social-rings-sip.md
@@ -1,0 +1,5 @@
+---
+"happy-harmony": patch
+---
+
+JANDES-122: Apply migrations and deploy to staging on merge to mainline

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,53 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [mainline]
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+      VITE_SENTRY_ORG: ${{ vars.VITE_SENTRY_ORG }}
+      VITE_SENTRY_PROJECT: ${{ vars.VITE_SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Write staging wrangler config
+        run: node scripts/write-staging-wrangler.mjs
+
+      - name: Apply staging DB migrations
+        run: pnpm db:migrate:staging
+
+      - name: Deploy staging worker
+        run: pnpm exec wrangler deploy --config dist/server/wrangler.staging.json

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -39,4 +39,4 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          pnpm exec wrangler delete --env staging --name "happy-harmony-pr-${PR_NUMBER}" --force
+          pnpm exec wrangler delete --env staging --name "happy-harmony-pr-${PR_NUMBER}" --force || true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require("@actions/core");
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
 


### PR DESCRIPTION
# JANDES-122: Automated staging deploy on mainline merge

## Summary

- Adds `deploy-staging.yml` — triggers on every push to `mainline`, runs build → apply staging D1 migrations → deploy `happy-harmony-staging` worker
- Fixes `pr-preview-cleanup.yml` — cleanup no longer fails when a PR was merged before its preview worker was ever deployed

## How it works

On every push to `mainline`, the `Deploy Staging` workflow:
1. Builds the app (`pnpm build`)
2. Writes the staging wrangler config (`node scripts/write-staging-wrangler.mjs`)
3. Applies any pending D1 migrations to the staging database (`pnpm db:migrate:staging`)
4. Deploys the `happy-harmony-staging` worker (`wrangler deploy --config dist/server/wrangler.staging.json`)

Migrations always run before the deploy, so staging stays schema-consistent with the latest mainline code.

## Why migrations run as a separate step (not via `pnpm deploy:staging`)

`deploy:staging` runs build → write config → deploy in one command. Migrations need to happen between the config-write and the deploy, so the steps are split explicitly in the workflow.

## Cleanup fix

PR preview workers are deleted when a PR closes. If a PR is merged before the preview deploy finishes (e.g. merged within ~90 seconds of opening), there's no worker to delete and `wrangler delete` exits non-zero. Added `|| true` so the cleanup job doesn't fail in that case.

## Changed files

| File | Change |
|------|--------|
| `.github/workflows/deploy-staging.yml` | New — automated staging deploy on mainline push |
| `.github/workflows/pr-preview-cleanup.yml` | Fix — tolerate missing preview worker on delete |

## Required secrets

`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `SENTRY_AUTH_TOKEN` must be set. These are already present from the PR preview workflows.

## Test plan

- [ ] Merge a commit to `mainline` and confirm `Deploy Staging` workflow appears and completes
- [ ] Verify `staging.happyharmony.dev` reflects the merged code after the workflow completes
- [ ] Confirm wrangler output shows migrations applied (or "no pending migrations")
- [ ] Close a PR that was merged before its preview deployed — confirm the cleanup job passes instead of failing
